### PR TITLE
feat: implement flight lookup

### DIFF
--- a/backend/backend/data/flights.json
+++ b/backend/backend/data/flights.json
@@ -5,4 +5,4 @@
   "flightDuration" : 9000.000000000,
   "availableSeats" : [ "1A", "1B", "2A" ],
   "onWayFlight" : false
-} ]
+}]

--- a/backend/backend/src/main/java/dom/lot/backend/controller/FlightController.java
+++ b/backend/backend/src/main/java/dom/lot/backend/controller/FlightController.java
@@ -23,6 +23,12 @@ public class FlightController {
         return ResponseEntity.ok(flights);
     }
 
+    @GetMapping("/{flightNumber}")
+    public ResponseEntity<Flight> getFlightByFlightNumber(@PathVariable String flightNumber) {
+        Flight flight = flightService.getFlightByFlightNumber(flightNumber);
+        return ResponseEntity.ok(flight);
+    }
+
     @PostMapping
     public ResponseEntity<String> addFlight(@RequestBody Flight flight) {
         flightService.addFlight(flight);

--- a/backend/backend/src/main/java/dom/lot/backend/service/FlightService.java
+++ b/backend/backend/src/main/java/dom/lot/backend/service/FlightService.java
@@ -1,6 +1,7 @@
 package dom.lot.backend.service;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import dom.lot.backend.exception.FlightNotFoundException;
 import dom.lot.backend.model.Flight;
 import dom.lot.backend.util.JsonDataAccess;
 import org.springframework.stereotype.Service;
@@ -8,6 +9,7 @@ import org.springframework.stereotype.Service;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class FlightService {
@@ -33,5 +35,12 @@ public class FlightService {
     public void addFlight(Flight flight) {
         flights.add(flight);
         saveFlights();
+    }
+
+    public Flight getFlightByFlightNumber(String flightNumber) {
+        return flights.stream()
+                .filter((flight) -> flightNumber.equals(flight.getFlightNumber()))
+                .findFirst()
+                .orElseThrow(() -> new FlightNotFoundException(flightNumber));
     }
 }


### PR DESCRIPTION
Implement the flight lookup endpoint to using exception-based control flow:

- `FlightService` throws `FlightNotFoundException` when a flight is not found
- `FlightController` simplified – no more manual 404 logic
- Integrated with global error handler for clean JSON output

Makes the API more idiomatic and maintainable.