### PR TITLE
feat: add DELETE endpoint to remove flights by flight number

### DIFF
--- a/backend/backend/data/flights.json
+++ b/backend/backend/data/flights.json
@@ -5,4 +5,4 @@
   "flightDuration" : 9000.000000000,
   "availableSeats" : [ "1A", "1B", "2A" ],
   "onWayFlight" : false
-}]
+} ]

--- a/backend/backend/src/main/java/dom/lot/backend/controller/FlightController.java
+++ b/backend/backend/src/main/java/dom/lot/backend/controller/FlightController.java
@@ -34,4 +34,10 @@ public class FlightController {
         flightService.addFlight(flight);
         return ResponseEntity.status(HttpStatus.CREATED).body("Flight added successfully");
     }
+
+    @DeleteMapping("/{flightNumber}")
+    public ResponseEntity<String> deleteFlight(@PathVariable String flightNumber) {
+        flightService.deleteFlight(flightNumber);
+        return ResponseEntity.ok("Flight deleted successfully");
+    }
 }

--- a/backend/backend/src/main/java/dom/lot/backend/service/FlightService.java
+++ b/backend/backend/src/main/java/dom/lot/backend/service/FlightService.java
@@ -43,4 +43,9 @@ public class FlightService {
                 .findFirst()
                 .orElseThrow(() -> new FlightNotFoundException(flightNumber));
     }
+
+    public void deleteFlight(String flightNumber) {
+        Flight flight = getFlightByFlightNumber(flightNumber);
+        flights.remove(flight);
+    }
 }


### PR DESCRIPTION
This PR introduces the ability to delete flights using the API.

- Added `DELETE /api/flights/{flightNumber}`
- Integrated with existing exception-based lookup
- Returns 200 if deletion is successful, 404 if flight not found